### PR TITLE
Fixed typo about boot signature and sectors 511 and 512

### DIFF
--- a/Chapter-3/README.md
+++ b/Chapter-3/README.md
@@ -8,7 +8,7 @@ The BIOS boot sequence is: RAM detection -> Hardware detection/Initialization ->
 
 The most important step for us is the "Boot sequence", where the BIOS is done with its initialization and tries to transfer control to the next stage of the bootloader process.
 
-During the "Boot sequence", the BIOS will try to determine a "boot device" (e.g. floppy disk, hard-disk, CD, USB flash memory device or network). Our Operating System will initially boot from the hard-disk (but it will be possible to boot it from a CD or a USB flash memory device in future). A device is considered bootable if the bootsector contains the valid signature bytes `0x55` and `0xAA` at sectors 511 and 512 respectively.
+During the "Boot sequence", the BIOS will try to determine a "boot device" (e.g. floppy disk, hard-disk, CD, USB flash memory device or network). Our Operating System will initially boot from the hard-disk (but it will be possible to boot it from a CD or a USB flash memory device in future). A device is considered bootable if the bootsector contains the valid signature bytes `0x55` and `0xAA` at offsets 511 and 512 respectively.
 
 BIOS physically searches for a boot device by loading the first 512 bytes from the bootsector of each device into physical memory, starting at the address `0x7C00` (1 KiB below the 32 KiB mark). When the valid signature bytes are detected, BIOS transfers control to the `0x7C00` memory address (via a jump instruction) in order to execute the bootsector code.
 


### PR DESCRIPTION
Statement "signature bytes `0x55` and `0xAA` at _sectors_ 511 and 512 respectively." isn't correct. There should be "offsets" instead of "sectors", because signature belongs only to first (mbr) sector, not to 511th and 512th sectors.
