### PR TITLE
modtify May not run correctly place

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ build:
 
 run:
 	@echo "Running Dev Operating System."
-	cd ./sdk && sudo ./diskimage.sh
+	cd ./sdk && sudo bash ./diskimage.sh
 	cd ./sdk && ./qemu.sh
 
 clean:


### PR DESCRIPTION
The emergence of the following result according to the book's step operation make run
vagrant@lucid32:/vagrant$ make run 
Running Dev Operating System.
cd ./sdk && sudo ./diskimage.sh
sudo: ./diskimage.sh: command not found
make: **\* [run] Error 1
so I add bash in the front of ./diskimage.sh Because when creating diskimage may forget to add execute permissions
