### PR TITLE
Switch to Ubuntu Xenial

### DIFF
--- a/Chapter-2/README.md
+++ b/Chapter-2/README.md
@@ -17,13 +17,7 @@ Vagrant needs Virtualbox to work, Download and install for your system at https:
 
 ### Start and test your development environment
 
-Once Vagrant and Virtualbox are installed, you need to download the ubuntu lucid32 image for Vagrant:
-
-```
-vagrant box add lucid32 http://files.vagrantup.com/lucid32.box
-```
-
-Once the lucid32 image is ready, we need to define our development environment using a *Vagrantfile*, [create a file named *Vagrantfile*](https://github.com/SamyPesse/How-to-Make-a-Computer-Operating-System/blob/master/src/Vagrantfile). This file defines what prerequisites our environment needs: nasm, make, build-essential, grub and qemu.
+Once Vagrant and Virtualbox are installed, we need to define our development environment using a *Vagrantfile*, [create a file named *Vagrantfile*](https://github.com/SamyPesse/How-to-Make-a-Computer-Operating-System/blob/master/src/Vagrantfile). This file contains instructions to download the ubuntu xenial32 image. It also defines what prerequisites our environment needs: nasm, make, build-essential, grub and qemu.
 
 Start your box using:
 
@@ -37,7 +31,7 @@ You can now access your box by using ssh to connect to the virtual box using:
 vagrant ssh
 ```
 
-The directory containing the *Vagrantfile* will be mounted by default in the */vagrant* directory of the guest VM (in this case, Ubuntu Lucid32):
+The directory containing the *Vagrantfile* will be mounted by default in the */vagrant* directory of the guest VM (in this case, Ubuntu Xenial 32):
 
 ```
 cd /vagrant

--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -10,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "lucid32"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
+  config.vm.box = "ubuntu/xenial32"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/src/sdk/qemu.sh
+++ b/src/sdk/qemu.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-qemu -m 1024 -s -hda ./c.img  -curses -serial /dev/tty  -redir tcp:2323::23
+qemu-system-i386 -m 1024 -s -hda ./c.img  -curses -serial /dev/tty  -redir tcp:2323::23


### PR DESCRIPTION
Update to Ubuntu xenial32 since lucid32 is no longer supported and causes 404 errors when apt-get update is executed (Issue #110 ).
