### PR TITLE
Fixes compilation/run errors

### DIFF
--- a/src/kernel/runtime/cxx.cc
+++ b/src/kernel/runtime/cxx.cc
@@ -69,7 +69,11 @@ void operator delete(void *ptr)
 {
 		kfree(ptr);
 }
-
+//This function needs to be looked into but for now it allows compilation
+void operator delete(void *ptr, unsigned int k) 
+{
+		kfree(ptr);
+}
 #ifndef __arm__
 void* operator new(size_t len) 
 {

--- a/src/sdk/qemu.sh
+++ b/src/sdk/qemu.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-qemu -m 1024 -s -hda ./c.img  -curses -serial /dev/tty  -redir tcp:2323::23
+qemu-system-i386 -m 1024 -s -hda ./c.img  -curses -serial /dev/tty  -redir tcp:2323::23


### PR DESCRIPTION
Replaced qemu with qemu-system-i386 to run and added a void operator delete(void *ptr, unsigned int k) to compile. No functionality added