### PR TITLE
docs: fix simple typo, writting -> writing

### DIFF
--- a/Chapter-7/README.md
+++ b/Chapter-7/README.md
@@ -126,7 +126,7 @@ void init_idt(void)
 }
 ```
 
-After intialization of our IDT, we need to activate interrupts by configuring the PIC. The following function will configure the two PICs by writting in their internal registries using the output ports of the processor ```io.outb```. We configure the PICs using the ports:
+After intialization of our IDT, we need to activate interrupts by configuring the PIC. The following function will configure the two PICs by writing in their internal registries using the output ports of the processor ```io.outb```. We configure the PICs using the ports:
 
 * Master PIC: 0x20 and 0x21
 * Slave PIC: 0xA0 and 0xA1

--- a/Chapter-8/README.md
+++ b/Chapter-8/README.md
@@ -36,7 +36,7 @@ The two types of entries (table and directory) look like the same. Only the fiel
 ![Page table entry](./page_table_entry.png)
 
 * `P`: indicate if the page or table is in physical memory
-* `R/W`: indicate if the page or table is accessible in writting (equals 1)
+* `R/W`: indicate if the page or table is accessible in writing (equals 1)
 * `U/S`: equals 1 to allow access to non-preferred tasks
 * `A`: indicate if the page or table was accessed
 * `D`: (only for pages table) indicate if the page was written


### PR DESCRIPTION
There is a small typo in Chapter-7/README.md, Chapter-8/README.md.

Should read `writing` rather than `writting`.

