### PR TITLE
Updated the vagrantfile to follow the new method Vagrant uses to download boxes

### DIFF
--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -9,12 +9,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "lucid32"
-
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
+  config.vm.box = "lvphu609/lucid32"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
Updated the vagrantfile to follow the new method Vagrant uses to download boxes. Avoiding this error below:

 ```
An error occurred while downloading the remote file. The error message, if any, is reproduced below. Please fix this error and try again.
```